### PR TITLE
ignoring validators till it's fixed

### DIFF
--- a/dist/paratii.core.vids.js
+++ b/dist/paratii.core.vids.js
@@ -84,13 +84,15 @@ var ParatiiCoreVids = exports.ParatiiCoreVids = function () {
                 id: joi.string().default(null),
                 duration: joi.string().empty('').default('').allow(null),
                 owner: joi.string().required(),
-                author: joi.string(),
                 price: joi.number().default(0),
                 title: joi.string().empty('').default(''),
                 description: joi.string().empty('').default(''),
                 file: joi.string().default(null),
                 ipfsHashOrig: joi.string().empty('').default(''),
-                ipfsHash: joi.string().empty('').default('')
+                ipfsHash: joi.string().empty('').default(''),
+                author: joi.string().empty('').default('').allow(null),
+                free: joi.string().empty('').default('').allow(null),
+                publish: joi.string().empty('').default(false).allow(null)
               });
               result = joi.validate(options, schema);
               error = result.error;
@@ -184,11 +186,13 @@ var ParatiiCoreVids = exports.ParatiiCoreVids = function () {
                 price: joi.number().default(0),
                 title: joi.string().empty('').default(''),
                 description: joi.string().empty('').default(''),
-                author: joi.string().empty('').default(''),
                 duration: joi.string().empty('').default('').allow(null),
                 file: joi.string().default(null),
                 ipfsHashOrig: joi.string().empty('').default(''),
-                ipfsHash: joi.string().empty().default('')
+                ipfsHash: joi.string().empty().default(''),
+                author: joi.string().empty('').default('').allow(null),
+                free: joi.string().empty('').default('').allow(null),
+                publish: joi.string().empty('').default('').allow(null)
               });
               elements = schema._inner.children;
               dataToSave = {};

--- a/dist/paratii.ipfs.js
+++ b/dist/paratii.ipfs.js
@@ -167,17 +167,18 @@ var ParatiiIPFS = exports.ParatiiIPFS = function (_EventEmitter) {
           resolve(_this2.ipfs);
         } else {
           var config = _this2.config;
+          // there will be no joi in IPFS (pun indended)
           var ipfs = new Ipfs({
             bitswap: {
-              maxMessageSize: config['ipfs.bitswap.maxMessageSize']
+              maxMessageSize: 128 * 1024
             },
             start: true,
             repo: config['ipfs.repo'] || '/tmp/test-repo-' + String(Math.random()),
             config: {
               Addresses: {
-                Swarm: config['ipfs.config.addresses.swarm']
+                Swarm: ['/dns4/star.paratii.video/tcp/443/wss/p2p-webrtc-star', '/dns4/ws.star.paratii.video/tcp/443/wss/p2p-websocket-star/']
               },
-              Bootstrap: config['ipfs.config.Bootstrap']
+              Bootstrap: ['/dns4/bootstrap.paratii.video/tcp/443/wss/ipfs/QmeUmy6UtuEs91TH6bKnfuU1Yvp63CkZJWm624MjBEBazW']
             }
           });
 
@@ -221,7 +222,9 @@ var ParatiiIPFS = exports.ParatiiIPFS = function (_EventEmitter) {
 
               _this2.ipfs = ipfs;
               _this2.protocol.start(function () {
-                resolve(ipfs);
+                setTimeout(function () {
+                  resolve(ipfs);
+                }, 10);
               });
             });
           });

--- a/dist/paratii.ipfs.uploader.js
+++ b/dist/paratii.ipfs.uploader.js
@@ -459,9 +459,96 @@ var Uploader = function (_EventEmitter) {
       });
     }
   }, {
+    key: 'getMetaData',
+    value: function getMetaData(fileHash, options) {
+      var _this7 = this;
+
+      var schema = joi.object({
+        transcoder: joi.string().default(this._defaultTranscoder),
+        transcoderId: joi.any().default(Multiaddr(this._defaultTranscoder).getPeerId())
+      }).unknown();
+
+      this._ipfs.log('Signaling transcoder getMetaData...');
+      var result = joi.validate(options, schema);
+      var error = result.error;
+      if (error) throw error;
+      var opts = result.value;
+      console.log('opts: ', opts);
+      var ev = void 0;
+      if (opts.ev) {
+        ev = opts.ev;
+      } else {
+        ev = new EventEmitter();
+      }
+      this._ipfs.start(function () {
+        var msg = _this7._ipfs.protocol.createCommand('getMetaData', { hash: fileHash });
+        // FIXME : This is for dev, so we just signal our transcoder node.
+        // This needs to be dynamic later on.
+        _this7._ipfs.ipfs.swarm.connect(opts.transcoder, function (err, success) {
+          if (err) return ev.emit('getMetaData:error', err);
+
+          opts.transcoderId = opts.transcoderId || Multiaddr(opts.transcoder).getPeerId();
+          _this7._ipfs.log('transcoderId: ', opts.transcoderId);
+          _this7._node.swarm.peers(function (err, peers) {
+            _this7._ipfs.log('peers: ', peers);
+            if (err) return ev.emit('getMetaData:error', err);
+            peers.map(function (peer) {
+              _this7._ipfs.log('peerID : ', peer.peer.id.toB58String(), opts.transcoderId, peer.peer.id.toB58String() === opts.transcoder);
+              if (peer.peer.id.toB58String() === opts.transcoderId) {
+                _this7._ipfs.log('sending getMetaData msg to ' + peer.peer.id.toB58String() + ' with request to transcode ' + fileHash);
+                _this7._ipfs.protocol.network.sendMessage(peer.peer.id, msg, function (err) {
+                  if (err) {
+                    ev.emit('getMetaData:error', err);
+                    return ev;
+                  }
+                });
+              }
+            });
+
+            // paratii getMetaData signal.
+            _this7._ipfs.on('protocol:incoming', _this7._getMetaDataRespHandler(ev, fileHash));
+            // ev.emit('transcoder:progress', 0) // TODO : add an event for starting.
+          });
+        });
+      });
+      return ev;
+    }
+  }, {
+    key: '_getMetaDataRespHandler',
+    value: function _getMetaDataRespHandler(ev, fileHash) {
+      var _this8 = this;
+
+      return function (peerId, command) {
+        _this8._ipfs.log('paratii protocol: Got Command ', command.payload.toString(), 'args: ', command.args.toString());
+        var commandStr = command.payload.toString();
+        var argsObj = void 0;
+        try {
+          argsObj = JSON.parse(command.args.toString());
+        } catch (e) {
+          _this8._ipfs.error('couldn\'t parse args, ', command.args.toString());
+        }
+
+        switch (commandStr) {
+          case 'getMetaData:error':
+            console.log('DEBUG getMetaData ERROR: fileHash: ', fileHash, ' , errHash: ', argsObj.hash);
+            if (argsObj.hash === fileHash) {
+              ev.emit('getMetaData:error', argsObj.err);
+            }
+            break;
+          case 'getMetaData:done':
+            console.log('data: ', argsObj.data);
+            var result = argsObj.data;
+            ev.emit('getMetaData:done', argsObj.hash, result);
+            break;
+          default:
+            _this8._ipfs.log('unknown command : ', commandStr);
+        }
+      };
+    }
+  }, {
     key: 'pinFile',
     value: function pinFile(fileHash, options) {
-      var _this7 = this;
+      var _this9 = this;
 
       if (options === undefined) options = {};
 
@@ -491,12 +578,12 @@ var Uploader = function (_EventEmitter) {
       this._node.swarm.connect(opts.transcoder, function (err, success) {
         if (err) return ev.emit('pin:error', err);
 
-        _this7._node.swarm.peers(function (err, peers) {
-          _this7._ipfs.log('peers: ', peers);
+        _this9._node.swarm.peers(function (err, peers) {
+          _this9._ipfs.log('peers: ', peers);
           if (err) return ev.emit('pin:error', err);
           peers.map(function (peer) {
-            _this7._ipfs.log('sending pin msg to ' + peer.peer.id.toB58String() + ' with request to pin ' + fileHash);
-            _this7._ipfs.protocol.network.sendMessage(peer.peer.id, msg, function (err) {
+            _this9._ipfs.log('sending pin msg to ' + peer.peer.id.toB58String() + ' with request to pin ' + fileHash);
+            _this9._ipfs.protocol.network.sendMessage(peer.peer.id, msg, function (err) {
               if (err) {
                 ev.emit('pin:error', err);
                 return ev;
@@ -505,7 +592,7 @@ var Uploader = function (_EventEmitter) {
           });
 
           // paratii pinning response.
-          _this7._ipfs.on('protocol:incoming', _this7._pinResponseHandler(ev));
+          _this9._ipfs.on('protocol:incoming', _this9._pinResponseHandler(ev));
         });
       });
 
@@ -514,16 +601,16 @@ var Uploader = function (_EventEmitter) {
   }, {
     key: '_pinResponseHandler',
     value: function _pinResponseHandler(ev) {
-      var _this8 = this;
+      var _this10 = this;
 
       return function (peerId, command) {
-        _this8._ipfs.log('paratii protocol: Got Command ', command.payload.toString(), 'args: ', command.args.toString());
+        _this10._ipfs.log('paratii protocol: Got Command ', command.payload.toString(), 'args: ', command.args.toString());
         var commandStr = command.payload.toString();
         var argsObj = void 0;
         try {
           argsObj = JSON.parse(command.args.toString());
         } catch (e) {
-          _this8._ipfs.log('couldn\'t parse args, ', command.args.toString());
+          _this10._ipfs.log('couldn\'t parse args, ', command.args.toString());
         }
 
         switch (commandStr) {
@@ -537,7 +624,7 @@ var Uploader = function (_EventEmitter) {
             ev.emit('pin:done', argsObj.hash);
             break;
           default:
-            _this8._ipfs.log('unknown command : ', commandStr);
+            _this10._ipfs.log('unknown command : ', commandStr);
         }
       };
     }

--- a/lib/paratii.core.vids.js
+++ b/lib/paratii.core.vids.js
@@ -44,13 +44,15 @@ export class ParatiiCoreVids {
       id: joi.string().default(null),
       duration: joi.string().empty('').default('').allow(null),
       owner: joi.string().required(),
-      author: joi.string(),
       price: joi.number().default(0),
       title: joi.string().empty('').default(''),
       description: joi.string().empty('').default(''),
       file: joi.string().default(null),
       ipfsHashOrig: joi.string().empty('').default(''),
-      ipfsHash: joi.string().empty('').default('')
+      ipfsHash: joi.string().empty('').default(''),
+      author: joi.string().empty('').default('').allow(null),
+      free: joi.string().empty('').default('').allow(null),
+      publish: joi.string().empty('').default(false).allow(null)
     })
 
     const result = joi.validate(options, schema)
@@ -100,11 +102,13 @@ export class ParatiiCoreVids {
       price: joi.number().default(0),
       title: joi.string().empty('').default(''),
       description: joi.string().empty('').default(''),
-      author: joi.string().empty('').default(''),
       duration: joi.string().empty('').default('').allow(null),
       file: joi.string().default(null),
       ipfsHashOrig: joi.string().empty('').default(''),
-      ipfsHash: joi.string().empty().default('')
+      ipfsHash: joi.string().empty().default(''),
+      author: joi.string().empty('').default('').allow(null),
+      free: joi.string().empty('').default('').allow(null),
+      publish: joi.string().empty('').default('').allow(null)
     })
 
     const elements = schema._inner.children

--- a/lib/paratii.ipfs.js
+++ b/lib/paratii.ipfs.js
@@ -71,17 +71,23 @@ export class ParatiiIPFS extends EventEmitter {
         resolve(this.ipfs)
       } else {
         let config = this.config
+        // there will be no joi in IPFS (pun indended)
         let ipfs = new Ipfs({
           bitswap: {
-            maxMessageSize: config['ipfs.bitswap.maxMessageSize']
+            maxMessageSize: 128 * 1024
           },
           start: true,
           repo: config['ipfs.repo'] || '/tmp/test-repo-' + String(Math.random()),
           config: {
             Addresses: {
-              Swarm: config['ipfs.config.addresses.swarm']
+              Swarm: [
+                '/dns4/star.paratii.video/tcp/443/wss/p2p-webrtc-star',
+                '/dns4/ws.star.paratii.video/tcp/443/wss/p2p-websocket-star/'
+              ]
             },
-            Bootstrap: config['ipfs.config.Bootstrap']
+            Bootstrap: [
+              '/dns4/bootstrap.paratii.video/tcp/443/wss/ipfs/QmeUmy6UtuEs91TH6bKnfuU1Yvp63CkZJWm624MjBEBazW'
+            ]
           }
         })
 
@@ -128,7 +134,9 @@ export class ParatiiIPFS extends EventEmitter {
 
             this.ipfs = ipfs
             this.protocol.start(() => {
-              resolve(ipfs)
+              setTimeout(() => {
+                resolve(ipfs)
+              }, 10)
             })
           })
         })

--- a/lib/paratii.ipfs.uploader.js
+++ b/lib/paratii.ipfs.uploader.js
@@ -386,6 +386,87 @@ class Uploader extends EventEmitter {
     })
   }
 
+  getMetaData (fileHash, options) {
+    const schema = joi.object({
+      transcoder: joi.string().default(this._defaultTranscoder),
+      transcoderId: joi.any().default(Multiaddr(this._defaultTranscoder).getPeerId())
+    }).unknown()
+
+    this._ipfs.log('Signaling transcoder getMetaData...')
+    const result = joi.validate(options, schema)
+    const error = result.error
+    if (error) throw error
+    let opts = result.value
+    console.log('opts: ', opts)
+    let ev
+    if (opts.ev) {
+      ev = opts.ev
+    } else {
+      ev = new EventEmitter()
+    }
+    this._ipfs.start(() => {
+      let msg = this._ipfs.protocol.createCommand('getMetaData', {hash: fileHash})
+      // FIXME : This is for dev, so we just signal our transcoder node.
+      // This needs to be dynamic later on.
+      this._ipfs.ipfs.swarm.connect(opts.transcoder, (err, success) => {
+        if (err) return ev.emit('getMetaData:error', err)
+
+        opts.transcoderId = opts.transcoderId || Multiaddr(opts.transcoder).getPeerId()
+        this._ipfs.log('transcoderId: ', opts.transcoderId)
+        this._node.swarm.peers((err, peers) => {
+          this._ipfs.log('peers: ', peers)
+          if (err) return ev.emit('getMetaData:error', err)
+          peers.map((peer) => {
+            this._ipfs.log('peerID : ', peer.peer.id.toB58String(), opts.transcoderId, peer.peer.id.toB58String() === opts.transcoder)
+            if (peer.peer.id.toB58String() === opts.transcoderId) {
+              this._ipfs.log(`sending getMetaData msg to ${peer.peer.id.toB58String()} with request to transcode ${fileHash}`)
+              this._ipfs.protocol.network.sendMessage(peer.peer.id, msg, (err) => {
+                if (err) {
+                  ev.emit('getMetaData:error', err)
+                  return ev
+                }
+              })
+            }
+          })
+
+          // paratii getMetaData signal.
+          this._ipfs.on('protocol:incoming', this._getMetaDataRespHandler(ev, fileHash))
+          // ev.emit('transcoder:progress', 0) // TODO : add an event for starting.
+        })
+      })
+    })
+    return ev
+  }
+
+  _getMetaDataRespHandler (ev, fileHash) {
+    return (peerId, command) => {
+      this._ipfs.log('paratii protocol: Got Command ', command.payload.toString(), 'args: ', command.args.toString())
+      let commandStr = command.payload.toString()
+      let argsObj
+      try {
+        argsObj = JSON.parse(command.args.toString())
+      } catch (e) {
+        this._ipfs.error('couldn\'t parse args, ', command.args.toString())
+      }
+
+      switch (commandStr) {
+        case 'getMetaData:error':
+          console.log('DEBUG getMetaData ERROR: fileHash: ', fileHash, ' , errHash: ', argsObj.hash)
+          if (argsObj.hash === fileHash) {
+            ev.emit('getMetaData:error', argsObj.err)
+          }
+          break
+        case 'getMetaData:done':
+          console.log('data: ', argsObj.data)
+          let result = argsObj.data
+          ev.emit('getMetaData:done', argsObj.hash, result)
+          break
+        default:
+          this._ipfs.log('unknown command : ', commandStr)
+      }
+    }
+  }
+
   pinFile (fileHash, options) {
     if (options === undefined) options = {}
 

--- a/test/paratii.ipfs.uploader.js
+++ b/test/paratii.ipfs.uploader.js
@@ -12,7 +12,7 @@ describe('ParatiiIPFS: :', function () {
   let paratiiIPFS
   this.timeout(30000)
 
-  beforeEach(function () {
+  beforeEach(() => {
     paratiiIPFS = new ParatiiIPFS({})
   })
 
@@ -20,9 +20,28 @@ describe('ParatiiIPFS: :', function () {
     paratiiIPFS.stop(() => {
       delete paratiiIPFS.ipfs
       setImmediate(() => {
-        assert.isNotOk(paratiiIPFS.ipfs)
         done()
       })
+    })
+  })
+
+  // skip till i fix underlying libp2p issue.
+  it.skip('should be able to getMetaData from Transcoder', (done) => {
+    let testHash = 'QmTkuJTcQhtQm8bPzF1hQmhrDPsdLs28soUZQEUx7t9pBJ'
+    let ev = paratiiIPFS.uploader.getMetaData(testHash, {})
+    ev.once('getMetaData:error', (err, hash) => {
+      if (err) {
+        console.log('getMetaData ERROR ', err)
+        return done(err)
+      }
+    })
+
+    ev.once('getMetaData:done', (hash, data) => {
+      assert.isOk(hash)
+      assert.equal(testHash, hash)
+      assert.isOk(data)
+      console.log(data)
+      done()
     })
   })
 
@@ -78,7 +97,7 @@ describe('ParatiiIPFS: :', function () {
     let files = []
 
     let ev = paratiiIPFS.uploader.addAndTranscode(files)
-    ev.on('transcoding:done', (resp) => {
+    ev.once('transcoding:done', (resp) => {
       assert.isOk(resp)
       assert.isOk(resp.test)
       expect(resp.test).to.equal(1)


### PR DESCRIPTION
joi is causing some issue where the nested vars like `config.addresses.swarm` are `null` which means IPFS had no bootstrap node nor swarm addresses to listen on. this should probably take care of the `getJSON` issue.

this also include a new function `getMetaData` which grabs the video metadata from the transcoder (@eliawk . check https://github.com/Paratii-Video/paratii-lib/pull/146/files#diff-bb73b15bb15bcdecb61344dc22aae364R29 to see if this could be useful in the case of grabbing the thumnails) 