### PR TITLE
activating ipfs relay 

### DIFF
--- a/dist/paratii.ipfs.js
+++ b/dist/paratii.ipfs.js
@@ -223,6 +223,14 @@ var ParatiiIPFS = exports.ParatiiIPFS = function (_EventEmitter) {
           }) // eslint-disable-line
           .then(function (Ipfs) {
             var ipfs = new Ipfs({
+              EXPERIMENTAL: { // enable experimental features
+                relay: {
+                  enabled: true, // enable circuit relay dialer and listener
+                  hop: {
+                    enabled: true // enable circuit relay HOP (make this node a relay)
+                  }
+                }
+              },
               bitswap: {
                 // maxMessageSize: 256 * 1024
                 maxMessageSize: _this2.config.ipfs['bitswap.maxMessageSize']

--- a/lib/paratii.ipfs.js
+++ b/lib/paratii.ipfs.js
@@ -102,6 +102,14 @@ export class ParatiiIPFS extends EventEmitter {
         import(/* webpackChunkName: 'ipfs' */ 'ipfs') // eslint-disable-line
         .then((Ipfs) => {
           let ipfs = new Ipfs({
+            EXPERIMENTAL: { // enable experimental features
+              relay: {
+                enabled: true, // enable circuit relay dialer and listener
+                hop: {
+                  enabled: true // enable circuit relay HOP (make this node a relay)
+                }
+              }
+            },
             bitswap: {
               // maxMessageSize: 256 * 1024
               maxMessageSize: this.config.ipfs['bitswap.maxMessageSize']


### PR DESCRIPTION
this activates the experimental `relay` functionality that was added to `js-ipfs` in version 0.28.2

ref: https://github.com/ipfs/js-ipfs/pull/1063